### PR TITLE
add c++ extension for channel_mixing

### DIFF
--- a/cpp/rwkv.cpp
+++ b/cpp/rwkv.cpp
@@ -1,0 +1,66 @@
+#include <ATen/ATen.h>
+#include <torch/library.h>
+#include <torch/extension.h>
+
+namespace at {
+
+
+template <typename scalar_t>
+void kernel_impl(
+    Tensor& xk,
+    Tensor& xr,
+    const Tensor& input,
+    const Tensor& state,
+    int64_t index,
+    const Tensor& k,
+    const Tensor& r) {
+
+  int64_t K = state.size(1);
+
+  scalar_t* input_data = input.data_ptr<scalar_t>();
+  scalar_t* k_data = k.data_ptr<scalar_t>();
+  scalar_t* r_data = r.data_ptr<scalar_t>();
+  scalar_t* xk_data = xk.data_ptr<scalar_t>();
+  scalar_t* xr_data = xr.data_ptr<scalar_t>();
+
+  // add offset
+  scalar_t* state_data = state.data_ptr<scalar_t>();
+  scalar_t* s_data = state_data + 5 * index * K;
+
+  #pragma omp simd
+  for (int64_t i = 0; i < K; ++i) {
+    xk_data[i] = input_data[i] * k_data[i] + s_data[i] * (1 - k_data[i]);
+    xr_data[i] = input_data[i] * r_data[i] + s_data[i] * (1 - r_data[i]);
+    s_data[i] = input_data[i];
+  }
+}
+
+Tensor channel_mixing_kernel(
+    const Tensor& input,
+    const Tensor& state,
+    int64_t index,
+    const Tensor& k,
+    const Tensor& r,
+    const Tensor& kw,
+    const Tensor& vw,
+    const Tensor& rw) {
+
+  TORCH_CHECK(input.device().is_cpu(), "input must be a CPU tensor");
+
+  int64_t K = input.size(0);
+  auto xk = at::zeros({K}, input.options());
+  auto xr = at::zeros({K}, input.options());
+  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "channel_mixing_kernel", [&]() {
+    return kernel_impl<scalar_t>(xk, xr, input, state, index, k, r);
+  });
+
+  auto rr = torch::sigmoid(torch::matmul(rw, xr));
+  auto kk = torch::square(torch::relu(torch::matmul(kw, xk)));
+  return rr * torch::matmul(vw, kk);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("channel_mixing", &channel_mixing_kernel, "RWKV channel mixing forward");
+}
+
+} // namespace at

--- a/cpp/rwkv.py
+++ b/cpp/rwkv.py
@@ -1,0 +1,37 @@
+import math
+from torch import nn
+from torch.autograd import Function
+import torch
+
+import rwkv_cpp
+
+torch.manual_seed(42)
+
+
+class RWKVFunction(Function):
+    @staticmethod
+    def forward(ctx, input, weights, bias, old_h, old_cell):
+        outputs = rwkv_cpp.forward(input, weights, bias, old_h, old_cell)
+        new_h, new_cell = outputs[:2]
+        variables = outputs[1:] + [weights]
+        ctx.save_for_backward(*variables)
+
+        return new_h, new_cell
+
+class RWKV(nn.Module):
+    def __init__(self, input_features, state_size):
+        super(RWKV, self).__init__()
+        self.input_features = input_features
+        self.state_size = state_size
+        self.weights = nn.Parameter(
+            torch.Tensor(3 * state_size, input_features + state_size))
+        self.bias = nn.Parameter(torch.Tensor(1, 3 * state_size))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        stdv = 1.0 / math.sqrt(self.state_size)
+        for weight in self.parameters():
+            weight.data.uniform_(-stdv, +stdv)
+
+    def forward(self, input, state):
+        return RWKVFunction.apply(input, self.weights, self.bias, *state)

--- a/cpp/setup.py
+++ b/cpp/setup.py
@@ -1,0 +1,31 @@
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CppExtension
+
+use_openmp = True
+print(f"  USE_OPEN: {use_openmp}")
+use_avx512 = True
+print(f"  USE_AVX512: {use_avx512}")
+
+extra_compile_args = {"cxx": []}
+
+if use_openmp:
+    extra_compile_args["cxx"].append("-fopenmp")
+
+if use_avx512:
+    extra_compile_args["cxx"].append("-O3")
+    extra_compile_args["cxx"].append("-march=skylake-avx512")
+    extra_compile_args["cxx"].append("-mavx512f")
+    extra_compile_args["cxx"].append("-DCPU_CAPABILITY_AVX512")
+    extra_compile_args["cxx"].append("-Wno-array-bounds -Wno-unknown-pragmas")
+
+setup(
+    name='rwkv_cpp',
+    ext_modules=[
+        CppExtension(
+            'rwkv_cpp',
+            ['rwkv.cpp'],
+            extra_compile_args=extra_compile_args),
+    ],
+    cmdclass={
+        'build_ext': BuildExtension
+    })

--- a/run_inference_bench.sh
+++ b/run_inference_bench.sh
@@ -1,0 +1,25 @@
+#
+# jemalloc: https://github.com/jemalloc/jemalloc/wiki/Getting-Started
+   export MALLOC_CONF="oversize_threshold:1,background_thread:true,metadata_thp:auto,dirty_decay_ms:-1,muzzy_decay_ms:-1";
+   export LD_PRELOAD=/home/mingfeim/packages/jemalloc-5.2.1/lib/libjemalloc.so
+
+INPUT_FILE="RWKV_in_150_lines.py"
+
+CORES=`lscpu | grep Core | awk '{print $4}'`
+SOCKETS=`lscpu | grep Socket | awk '{print $2}'`
+TOTAL_CORES=`expr $CORES \* $SOCKETS`
+LAST_CORE=`expr $CORES - 1`
+
+KMP_BLOCKTIME=1
+
+PREFIX="numactl --physcpubind=0-$LAST_CORE --membind=0"
+
+export KMP_BLOCKTIME=$KMP_BLOCKTIME
+
+echo -e "### using KMP_BLOCKTIME=$KMP_BLOCKTIME\n"
+
+## single socket test
+echo -e "\n### using OMP_NUM_THREADS=$CORES"
+PREFIX="numactl --physcpubind=0-$LAST_CORE --membind=0"
+echo -e "### using $PREFIX\n"
+OMP_NUM_THREADS=$CORES $PREFIX python -u $INPUT_FILE


### PR DESCRIPTION
This one is only a reference implementation for adding C++ extension to a pytorch model.

To install,
```
cd cpp
python setup.py install
```

To run,
```
./run_inference_bench.py
```

### Generally we can do optimizations in the following steps:

1. collect original performance, add timing to your scripts:
`### Finishing  3  trials in 10.137 sec.`

2. set jemalloc and env variables, take `run_inference_bench.sh` as a reference:
`### Finishing  3  trials in 8.782 sec.`

3. do profiling
```
STAGE:2023-03-13 09:50:22 160644:160644 ActivityProfilerController.cpp:317] Completed Stage: Collection
STAGE:2023-03-13 09:50:22 160644:160644 ActivityProfilerController.cpp:321] Completed Stage: Post Processing
-----------------------------  ------------  ------------  ------------  ------------  ------------  ------------
                         Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
-----------------------------  ------------  ------------  ------------  ------------  ------------  ------------
                 aten::matmul        -0.28%  -22276.000us        65.98%        5.269s      91.434us         57629
                     aten::mv         2.92%     233.383ms        65.02%        5.192s      90.102us         57629
                 aten::addmv_        63.20%        5.047s        63.20%        5.047s      87.586us         57629
               channel_mixing         2.78%     221.876ms        48.48%        3.872s     473.113us          8184
                  time_mixing         7.60%     607.277ms        37.73%        3.014s     368.244us          8184
                    aten::add         4.40%     351.021ms         6.72%     536.588ms       3.642us        147331
                     aten::to         0.66%      52.591ms         4.27%     341.169ms       6.689us         51005
               aten::_to_copy         1.24%      99.087ms         3.77%     301.294ms       7.251us         41550
                  aten::copy_         3.12%     249.211ms         3.12%     249.211ms       3.022us         82476
                    aten::mul         2.88%     230.295ms         2.88%     230.295ms       1.563us        147312
                 aten::select         2.49%     198.858ms         2.51%     200.124ms       1.875us        106757
             aten::layer_norm         0.30%      23.668ms         2.33%     185.928ms      10.905us         17050
      aten::native_layer_norm         1.84%     146.674ms         2.04%     162.801ms       9.548us         17050
                   aten::relu         0.37%      29.372ms         1.05%      83.605ms      10.216us          8184
                 aten::square         0.18%      14.175ms         0.99%      78.858ms       9.636us          8184
                    aten::exp         0.92%      73.430ms         0.92%      73.430ms       2.241us         32760
                    aten::pow         0.82%      65.514ms         0.82%      65.572ms       8.012us          8184
                aten::sigmoid         0.82%      65.392ms         0.82%      65.392ms       3.995us         16368
                    aten::neg         0.74%      59.349ms         0.74%      59.349ms       1.450us         40944
              aten::clamp_min         0.68%      54.289ms         0.68%      54.289ms       6.634us          8184
                    aten::sub         0.54%      42.873ms         0.54%      42.873ms       1.310us         32736
                aten::maximum         0.42%      33.484ms         0.42%      33.484ms       2.046us         16368
                aten::softmax         0.02%       1.532ms         0.38%      30.263ms     100.877us           300
               aten::_softmax         0.37%      29.324ms         0.37%      29.324ms      97.747us           300
                    aten::div         0.30%      23.932ms         0.30%      23.932ms       2.924us          8184
                  aten::empty         0.24%      19.281ms         0.24%      19.281ms       0.176us        109397
          aten::empty_strided         0.21%      16.759ms         0.21%      16.759ms       0.403us         41556
                   aten::view         0.18%      14.041ms         0.18%      14.041ms       0.412us         34100
                 aten::detach         0.01%     988.000us         0.03%       2.373ms       7.910us           300
                       detach         0.02%       1.395ms         0.02%       1.395ms       4.650us           300
             aten::as_strided         0.02%       1.314ms         0.02%       1.314ms       0.012us        106997
                  aten::clone         0.00%      26.000us         0.01%     678.000us     113.000us             6
                aten::squeeze         0.01%     447.000us         0.01%     495.000us       2.062us           240
                  aten::fill_         0.00%     269.000us         0.00%     276.000us      11.040us            25
                  aten::zeros         0.00%      15.000us         0.00%     262.000us     262.000us             1
                  aten::zero_         0.00%       9.000us         0.00%     237.000us     237.000us             1
                aten::detach_         0.00%      65.000us         0.00%      72.000us       0.114us           630
                   aten::set_         0.00%      50.000us         0.00%      50.000us       0.079us           630
            aten::result_type         0.00%      33.000us         0.00%      33.000us       0.004us          8184
                      detach_         0.00%      12.000us         0.00%      12.000us       0.019us           630
                   aten::item         0.00%       5.000us         0.00%       7.000us       0.292us            24
                     defaults         0.00%       6.000us         0.00%       6.000us       0.857us             7
             aten::lift_fresh         0.00%       2.000us         0.00%       2.000us       0.003us           654
    aten::_local_scalar_dense         0.00%       2.000us         0.00%       2.000us       0.083us            24
           aten::resolve_conj         0.00%       2.000us         0.00%       2.000us       0.007us           300
            aten::resolve_neg         0.00%       0.000us         0.00%       0.000us       0.000us           300
-----------------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 7.987s

### Finishing  3  trials in 76.050 sec.
```

we can get a couple of important information from the profiling logs: a) bottleneck is gemv; b) we can add c++ extension to the workload, but the overall gain will be marginal.

gemv shapes: {1024x1024, 1024x1}, {4096x1024, 1024x1}, {1024x4096, 4096x1}.

4. do shape profiling. This is the step for c++ kernel implementation, we need to collect the input shape info
```### channel_mixing
x: [1024]
state:  [120, 1024]
time_mix_k:  [1024]
time_mix_r:  [1024]
kw:  [4096, 1024]
vw:  [1024, 4096]
rw:  [1024, 1024]
```

5. add c++ extension, take `rwkv.cpp` as a reference. The original python script is separated into pieces by `gemv`, not much left to be fused, and the shape for the fused kernel (1024) is not very big. Which is not worth of paralleling.

after injecting c++ extension for `channel_mixing`:
`### Finishing  3  trials in 8.365 sec.`


### Additional opportunity:

The following are additional opportunities, but will require more efforts: we can use `cblas_gemm_bf16bf16f32_compute` to do `BFloat16` gemm: this will require prepack the weights.

### Notes:
be careful that `pragma omp simd` will not auto-vectorize `exp`(thus `sigmoid`) with GCC;