### PR TITLE
Use fp32 atomicAdd in one mode kernel.

### DIFF
--- a/rwkv_pip_package/src/rwkv/cuda/operators.cu
+++ b/rwkv_pip_package/src/rwkv/cuda/operators.cu
@@ -105,7 +105,7 @@ __global__ void kernel_mm8_one(
     const __half *__restrict__ const rx,
     const __half *__restrict__ const my,
     const __half *__restrict__ const ry,
-    __half *__restrict__ const y) {
+    float *__restrict__ const y) {
 
     const int k = blockIdx.y * blockDim.y + threadIdx.y;
     const int j0 = min(N, blockIdx.x * ((N + MM8_ONE_JSPLIT - 1) / MM8_ONE_JSPLIT));
@@ -120,7 +120,7 @@ __global__ void kernel_mm8_one(
                 + __half2float(mx[k]) + __half2float(my[j])
             );
         }
-        atomicAdd(&y[k], __float2half(y_local));
+        atomicAdd(&y[k], y_local);
     }
 }
 void cuda_mm8_one(int N, int M,
@@ -128,10 +128,10 @@ void cuda_mm8_one(int N, int M,
                   uint8_t *w, int w_stride,
                   fp16 *mx, fp16 *rx,
                   fp16 *my, fp16 *ry,
-                  fp16 *y) {
+                  float *y) {
     dim3 blockSize(1, MM8_ONE_TILE);
     dim3 gridSize(MM8_ONE_JSPLIT, (M + blockSize.y - 1) / blockSize.y);
     kernel_mm8_one<<<gridSize, blockSize>>>(
         N, M, cast(x), w, w_stride,
-        cast(mx), cast(rx), cast(my), cast(ry), cast(y));
+        cast(mx), cast(rx), cast(my), cast(ry), y);
 }

--- a/rwkv_pip_package/src/rwkv/cuda/wrapper.cpp
+++ b/rwkv_pip_package/src/rwkv/cuda/wrapper.cpp
@@ -15,7 +15,7 @@ void cuda_mm8_one(int N, int M,
                   uint8_t *w, int w_stride,
                   fp16 *mx, fp16 *rx,
                   fp16 *my, fp16 *ry,
-                  fp16 *y);
+                  float *y);
 
 void wkv_forward(int64_t B, int64_t T, int64_t C, torch::Tensor &w, torch::Tensor &u, torch::Tensor &k, torch::Tensor &v, torch::Tensor &y, torch::Tensor &aa, torch::Tensor &bb, torch::Tensor &pp) {
     cuda_wkv_forward(B, T, C, w.data_ptr<float>(), u.data_ptr<float>(), k.data_ptr<fp16>(), v.data_ptr<fp16>(), y.data_ptr<fp16>(), aa.data_ptr<float>(), bb.data_ptr<float>(), pp.data_ptr<float>());
@@ -54,7 +54,7 @@ void mm8_one(int64_t N, int64_t M,
         w.data_ptr<uint8_t>(), w.stride(0),
         mx.data_ptr<fp16>(), rx.data_ptr<fp16>(),
         my.data_ptr<fp16>(), ry.data_ptr<fp16>(),
-        y.data_ptr<fp16>());
+        y.data_ptr<float>());
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {

--- a/rwkv_pip_package/src/rwkv/model.py
+++ b/rwkv_pip_package/src/rwkv/model.py
@@ -63,9 +63,9 @@ if os.environ.get('RWKV_CUDA_ON') == '1':
         assert w.shape == [N, M]
         assert rx.shape == mx.shape == [M]
         assert ry.shape == my.shape == [N, 1]
-        y = torch.zeros((M,), device=w.device, dtype=torch.float16)
+        y = torch.zeros((M,), device=w.device, dtype=torch.float32)
         torch.ops.rwkv.mm8_one(N, M, x, w, mx, rx, my, ry, y)
-        return y
+        return y.to(dtype=torch.float16)
 else:
     os.environ["RWKV_CUDA_ON"] = '0'
 


### PR DESCRIPTION
It's faster than fp16 atomicAdd, don't know exactly why. Since it has both better performance and accuracy, I'm using it for all arch.

Should fix #38, need tests on older cards (I don't have one in hand).