### PR TITLE
Validate strategy with regex

### DIFF
--- a/rwkv_pip_package/src/rwkv/model.py
+++ b/rwkv_pip_package/src/rwkv/model.py
@@ -10,6 +10,9 @@ torch.backends.cudnn.allow_tf32 = True
 torch.backends.cuda.matmul.allow_tf32 = True
 current_path = os.path.dirname(os.path.abspath(__file__))
 
+import re
+STRATEGY_REGEX = r"^(?:(?:^|->) *(?:cuda(?::[\d]+)?|cpu) (?:fp(?:16|32)|bf16)(?:i8|i4|i3)?(?: \*[\d]+\+?)? *)+$"
+
 ########################################################################################################
 
 if os.environ.get('RWKV_JIT_ON') != '0':
@@ -73,6 +76,8 @@ else:
 
 class RWKV(MyModule):
     def __init__(self, model, strategy):
+        if not re.match(STRATEGY_REGEX, strategy):
+            raise ValueError("bad strategy string, please check rwkv package page for docs")
         super().__init__()
         self.args = types.SimpleNamespace()
         args = self.args


### PR DESCRIPTION
This regex also filters out some strange strategies, such as `cuda fp16i9` For regex testing you can check https://regex101.com/r/iQmhGY/1

Note: for adding new quantization levels change `i8` to `i8|i4` or `i8|i4|i3`
![image](https://user-images.githubusercontent.com/44816767/226111180-60f9d7b8-aa63-4321-a997-fa0ea9085896.png)
