### PR TITLE
Adds instructions for CPU-only 'cpu bf16' mode

### DIFF
--- a/rwkv_pip_package/README.md
+++ b/rwkv_pip_package/README.md
@@ -82,4 +82,5 @@ out, state = model.forward([1563], state)           # RNN has state (use deepcop
 out, state = model.forward([310, 247], state)
 print(out.detach().cpu().numpy())                   # same result as above
 print('\n')
+
 ```

--- a/rwkv_pip_package/README.md
+++ b/rwkv_pip_package/README.md
@@ -82,5 +82,4 @@ out, state = model.forward([1563], state)           # RNN has state (use deepcop
 out, state = model.forward([310, 247], state)
 print(out.detach().cpu().numpy())                   # same result as above
 print('\n')
-
 ```

--- a/rwkv_pip_package/README.md
+++ b/rwkv_pip_package/README.md
@@ -46,7 +46,8 @@ os.environ["RWKV_CUDA_ON"] = '0' # '1' to compile CUDA kernel (10x faster), requ
 # Extreme STREAM: 3G VRAM is enough to run RWKV 14B (slow. will be faster in future)
 # 'cuda fp16i8 *0+ -> cpu fp32 *1' = stream all layers cuda fp16i8, last 1 layer [ln_out+head] cpu fp32
 #
-# If you want to use only RAM and cpu inference and have 35 GB RAM or more, 'cpu bf16'  is worth trying.
+# If you want to use only RAM and cpu inference and have 35 GB RAM or more and want to load the 14B model,
+# 'cpu bf16'  is worth trying.
 # ########################################################################################################
 
 from rwkv.model import RWKV

--- a/rwkv_pip_package/README.md
+++ b/rwkv_pip_package/README.md
@@ -38,7 +38,7 @@ os.environ["RWKV_CUDA_ON"] = '0' # '1' to compile CUDA kernel (10x faster), requ
 #  44% VRAM = 'cuda fp16i8 -> cpu fp32 *3'  # most layers cuda fp16i8, last 3 layers cpu fp32
 #  ...
 #   0% VRAM = 'cpu fp32'                    # all layers cpu fp32
-#   0% VRAM = 'cpu bf16'                    # all layers cpu bf16
+#   0% VRAM = 'cpu bf16'                    # most layers cpu bf16
 #
 # Use '+' for STREAM mode, which can save VRAM too, and it is sometimes faster
 # 'cuda fp16i8 *10+' = first 10 layers cuda fp16i8, then fp16i8 stream the rest to it (increase 10 for better speed)

--- a/rwkv_pip_package/README.md
+++ b/rwkv_pip_package/README.md
@@ -38,6 +38,7 @@ os.environ["RWKV_CUDA_ON"] = '0' # '1' to compile CUDA kernel (10x faster), requ
 #  44% VRAM = 'cuda fp16i8 -> cpu fp32 *3'  # most layers cuda fp16i8, last 3 layers cpu fp32
 #  ...
 #   0% VRAM = 'cpu fp32'                    # all layers cpu fp32
+#   0% VRAM = 'cpu bf16'                    # all layers cpu bf16
 #
 # Use '+' for STREAM mode, which can save VRAM too, and it is sometimes faster
 # 'cuda fp16i8 *10+' = first 10 layers cuda fp16i8, then fp16i8 stream the rest to it (increase 10 for better speed)
@@ -45,6 +46,7 @@ os.environ["RWKV_CUDA_ON"] = '0' # '1' to compile CUDA kernel (10x faster), requ
 # Extreme STREAM: 3G VRAM is enough to run RWKV 14B (slow. will be faster in future)
 # 'cuda fp16i8 *0+ -> cpu fp32 *1' = stream all layers cuda fp16i8, last 1 layer [ln_out+head] cpu fp32
 #
+# If you want to use only RAM and cpu inference and have 35 GB RAM or more, 'cpu bf16'  is worth trying.
 # ########################################################################################################
 
 from rwkv.model import RWKV


### PR DESCRIPTION
Gives instructions for running the 14B model with ~35 gigs of RAM cpu only. I'm not sure if this works without cuda but I think it will because I was able to get this to run even though I wasn't able to compile the CUDA kernel from streaming. 



Not sure what is up with the edit at the end of the file, I tried to fix it. Feel free to edit this branch to fix it if it's a problem. 