### PR TITLE
Fix fp32i8 when RWKV_CUDA_ON.

### DIFF
--- a/rwkv_pip_package/src/rwkv/cuda/operators.cu
+++ b/rwkv_pip_package/src/rwkv/cuda/operators.cu
@@ -4,10 +4,14 @@
 #include <cuda_fp16.h>
 #define MIN_VALUE (-1e38)
 typedef at::Half fp16;
+__half *cast(fp16 *ptr) {
+    return reinterpret_cast<__half *>(ptr);
+}
 
+template <typename F>
 __global__ void kernel_wkv_forward(const int B, const int T, const int C,
-                               const float *__restrict__ const _w, const float *__restrict__ const _u, const fp16 *__restrict__ const _k, const fp16 *__restrict__ const _v,
-                               fp16 *__restrict__ const _y, float *__restrict__ const _aa, float *__restrict__ const _bb, float *__restrict__ const _pp) {
+                               const float *__restrict__ const _w, const float *__restrict__ const _u, const F *__restrict__ const _k, const F *__restrict__ const _v,
+                               F *__restrict__ const _y, float *__restrict__ const _aa, float *__restrict__ const _bb, float *__restrict__ const _pp) {
     const int idx = blockIdx.x * blockDim.x + threadIdx.x;
     const int _b = idx / C;
     const int _c = idx % C;
@@ -16,9 +20,9 @@ __global__ void kernel_wkv_forward(const int B, const int T, const int C,
 
     float u = _u[_c];
     float w = _w[_c];
-    const fp16 *__restrict__ const k = _k + _offset;
-    const fp16 *__restrict__ const v = _v + _offset;
-    fp16 *__restrict__ const y = _y + _offset;
+    const F *__restrict__ const k = _k + _offset;
+    const F *__restrict__ const v = _v + _offset;
+    F *__restrict__ const y = _y + _offset;
 
     float aa = _aa[_state_offset];
     float bb = _bb[_state_offset];
@@ -31,7 +35,7 @@ __global__ void kernel_wkv_forward(const int B, const int T, const int C,
         float p = max(pp, ww);
         float e1 = exp(pp - p);
         float e2 = exp(ww - p);
-        y[ii] = fp16((e1 * aa + e2 * vv) / (e1 * bb + e2));
+        y[ii] = F((e1 * aa + e2 * vv) / (e1 * bb + e2));
         ww = w + pp;
         p = max(ww, kk);
         e1 = exp(ww - p);
@@ -45,18 +49,71 @@ __global__ void kernel_wkv_forward(const int B, const int T, const int C,
     _pp[_state_offset] = pp;
 }
 
-void cuda_wkv_forward(int B, int T, int C, float *w, float *u, fp16 *k, fp16 *v, fp16 *y, float *aa, float *bb, float *pp) {
+template <typename F>
+void cuda_wkv_forward(int B, int T, int C, float *w, float *u, F *k, F *v, F *y, float *aa, float *bb, float *pp) {
     dim3 threadsPerBlock( min(C, 32) );
     assert(B * C % threadsPerBlock.x == 0);
     dim3 numBlocks(B * C / threadsPerBlock.x);
     kernel_wkv_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, w, u, k, v, y, aa, bb, pp);
 }
 
-__half *cast(fp16 *ptr) {
-    return reinterpret_cast<__half *>(ptr);
+template void cuda_wkv_forward<fp16>(
+    int B, int T, int C,
+    float *w, float *u, fp16 *k, fp16 *v, fp16 *y,
+    float *aa, float *bb, float *pp);
+template void cuda_wkv_forward<float>(
+    int B, int T, int C,
+    float *w, float *u, float *k, float *v, float *y,
+    float *aa, float *bb, float *pp);
+
+__global__ void kernel_mm_seq_fp32i8(
+    const int B, const int N, const int M,
+    const float *__restrict__ const x, const int x_stride,
+    const uint8_t *__restrict__ const w, const int w_stride,
+    const float *__restrict__ const mx,
+    const float *__restrict__ const rx,
+    const float *__restrict__ const my,
+    const float *__restrict__ const ry,
+    float *__restrict__ const y, const int y_stride) {
+
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    const int k = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (i < B && k < M) {
+        float y_local = 0;
+        for (int j = 0; j < N; ++j) {
+            y_local += x[i * x_stride + j] * (
+                (float(w[j * w_stride + k]) + 0.5f)
+                * rx[k] * ry[j] + mx[k] + my[j]
+            );
+        }
+        y[i * y_stride + k] = y_local;
+    }
 }
 
-__global__ void kernel_mm8_seq(
+template <typename F>
+void cuda_mm8_seq(int B, int N, int M,
+                  F *x, int x_stride,
+                  uint8_t *w, int w_stride,
+                  F *mx, F *rx,
+                  F *my, F *ry,
+                  F *y, int y_stride);
+
+template <>
+void cuda_mm8_seq<float>(int B, int N, int M,
+                         float *x, int x_stride,
+                         uint8_t *w, int w_stride,
+                         float *mx, float *rx,
+                         float *my, float *ry,
+                         float *y, int y_stride) {
+    dim3 blockSize(1, 128);
+    dim3 gridSize((B + blockSize.x - 1) / blockSize.x, (M + blockSize.y - 1) / blockSize.y);
+    kernel_mm_seq_fp32i8<<<gridSize, blockSize>>>(
+        B, N, M, x, x_stride, w, w_stride,
+        mx, rx, my, ry, y, y_stride);
+}
+
+__global__ void kernel_mm_seq_fp16i8(
     const int B, const int N, const int M,
     const __half *__restrict__ const x, const int x_stride,
     const uint8_t *__restrict__ const w, const int w_stride,
@@ -81,15 +138,17 @@ __global__ void kernel_mm8_seq(
         y[i * y_stride + k] = __float2half(y_local);
     }
 }
-void cuda_mm8_seq(int B, int N, int M,
-                  fp16 *x, int x_stride,
-                  uint8_t *w, int w_stride,
-                  fp16 *mx, fp16 *rx,
-                  fp16 *my, fp16 *ry,
-                  fp16 *y, int y_stride) {
+
+template <>
+void cuda_mm8_seq<fp16>(int B, int N, int M,
+                        fp16 *x, int x_stride,
+                        uint8_t *w, int w_stride,
+                        fp16 *mx, fp16 *rx,
+                        fp16 *my, fp16 *ry,
+                        fp16 *y, int y_stride) {
     dim3 blockSize(1, 128);
     dim3 gridSize((B + blockSize.x - 1) / blockSize.x, (M + blockSize.y - 1) / blockSize.y);
-    kernel_mm8_seq<<<gridSize, blockSize>>>(
+    kernel_mm_seq_fp16i8<<<gridSize, blockSize>>>(
         B, N, M, cast(x), x_stride, w, w_stride,
         cast(mx), cast(rx), cast(my), cast(ry), cast(y), y_stride);
 }
@@ -97,7 +156,55 @@ void cuda_mm8_seq(int B, int N, int M,
 #define MM8_ONE_JSPLIT 24
 #define MM8_ONE_TILE 1024
 
-__global__ void kernel_mm8_one(
+__global__ void kernel_mm_one_fp32i8(
+    const int N, const int M,
+    const float *__restrict__ const x,
+    const uint8_t *__restrict__ const w, const int w_stride,
+    const float *__restrict__ const mx,
+    const float *__restrict__ const rx,
+    const float *__restrict__ const my,
+    const float *__restrict__ const ry,
+    float *__restrict__ const y) {
+
+    const int k = blockIdx.y * blockDim.y + threadIdx.y;
+    const int j0 = min(N, blockIdx.x * ((N + MM8_ONE_JSPLIT - 1) / MM8_ONE_JSPLIT));
+    const int j1 = min(N, (blockIdx.x + 1) * ((N + MM8_ONE_JSPLIT - 1) / MM8_ONE_JSPLIT));
+
+    if (k < M) {
+        float y_local = 0;
+        for (int j = j0; j < j1; ++j) {
+            y_local += x[j] * (
+                (float(w[j * w_stride + k]) + 0.5f)
+                * rx[k] * ry[j] + mx[k] + my[j]
+            );
+        }
+        atomicAdd(&y[k], y_local);
+    }
+}
+
+template <typename F>
+void cuda_mm8_one(int N, int M,
+                  F *x,
+                  uint8_t *w, int w_stride,
+                  F *mx, F *rx,
+                  F *my, F *ry,
+                  float *y);
+
+template <>
+void cuda_mm8_one<float>(int N, int M,
+                        float *x,
+                        uint8_t *w, int w_stride,
+                        float *mx, float *rx,
+                        float *my, float *ry,
+                        float *y) {
+    dim3 blockSize(1, MM8_ONE_TILE);
+    dim3 gridSize(MM8_ONE_JSPLIT, (M + blockSize.y - 1) / blockSize.y);
+    kernel_mm_one_fp32i8<<<gridSize, blockSize>>>(
+        N, M, x, w, w_stride,
+        mx, rx, my, ry, y);
+}
+
+__global__ void kernel_mm_one_fp16i8(
     const int N, const int M,
     const __half *__restrict__ const x,
     const uint8_t *__restrict__ const w, const int w_stride,
@@ -123,15 +230,17 @@ __global__ void kernel_mm8_one(
         atomicAdd(&y[k], y_local);
     }
 }
-void cuda_mm8_one(int N, int M,
-                  fp16 *x,
-                  uint8_t *w, int w_stride,
-                  fp16 *mx, fp16 *rx,
-                  fp16 *my, fp16 *ry,
-                  float *y) {
+
+template <>
+void cuda_mm8_one<fp16>(int N, int M,
+                        fp16 *x,
+                        uint8_t *w, int w_stride,
+                        fp16 *mx, fp16 *rx,
+                        fp16 *my, fp16 *ry,
+                        float *y) {
     dim3 blockSize(1, MM8_ONE_TILE);
     dim3 gridSize(MM8_ONE_JSPLIT, (M + blockSize.y - 1) / blockSize.y);
-    kernel_mm8_one<<<gridSize, blockSize>>>(
+    kernel_mm_one_fp16i8<<<gridSize, blockSize>>>(
         N, M, cast(x), w, w_stride,
         cast(mx), cast(rx), cast(my), cast(ry), y);
 }

--- a/rwkv_pip_package/src/rwkv/cuda/wrapper.cpp
+++ b/rwkv_pip_package/src/rwkv/cuda/wrapper.cpp
@@ -5,24 +5,48 @@
 
 typedef at::Half fp16;
 
-void cuda_wkv_forward(int B, int T, int C, float *w, float *u, fp16 *k, fp16 *v, fp16 *y, float *aa, float *bb, float *pp);
+template <typename F>
+void cuda_wkv_forward(int B, int T, int C,
+                      float *w, float *u, F *k, F *v, F *y,
+                      float *aa, float *bb, float *pp);
+template <typename F>
 void cuda_mm8_seq(int B, int N, int M,
-                  fp16 *x, int x_stride,
+                  F *x, int x_stride,
                   uint8_t *w, int w_stride,
-                  fp16 *mx, fp16 *rx,
-                  fp16 *my, fp16 *ry,
-                  fp16 *y, int y_stride);
+                  F *mx, F *rx,
+                  F *my, F *ry,
+                  F *y, int y_stride);
+template <typename F>
 void cuda_mm8_one(int N, int M,
-                  fp16 *x,
+                  F *x,
                   uint8_t *w, int w_stride,
-                  fp16 *mx, fp16 *rx,
-                  fp16 *my, fp16 *ry,
+                  F *mx, F *rx,
+                  F *my, F *ry,
                   float *y);
 
-void wkv_forward(int64_t B, int64_t T, int64_t C, torch::Tensor &w, torch::Tensor &u, torch::Tensor &k, torch::Tensor &v, torch::Tensor &y, torch::Tensor &aa, torch::Tensor &bb, torch::Tensor &pp) {
+void wkv_forward(int64_t B, int64_t T, int64_t C,
+                 torch::Tensor &w, torch::Tensor &u,
+                 torch::Tensor &k, torch::Tensor &v, torch::Tensor &y,
+                 torch::Tensor &aa, torch::Tensor &bb, torch::Tensor &pp) {
     const at::cuda::OptionalCUDAGuard device_guard(device_of(w));
-    cuda_wkv_forward(B, T, C, w.data_ptr<float>(), u.data_ptr<float>(), k.data_ptr<fp16>(), v.data_ptr<fp16>(), y.data_ptr<fp16>(), aa.data_ptr<float>(), bb.data_ptr<float>(), pp.data_ptr<float>());
+    switch (k.scalar_type()) {
+    case c10::ScalarType::Half:
+        cuda_wkv_forward(B, T, C,
+                         w.data_ptr<float>(), u.data_ptr<float>(),
+                         k.data_ptr<fp16>(), v.data_ptr<fp16>(), y.data_ptr<fp16>(),
+                         aa.data_ptr<float>(), bb.data_ptr<float>(), pp.data_ptr<float>());
+        break;
+    case c10::ScalarType::Float:
+        cuda_wkv_forward(B, T, C,
+                         w.data_ptr<float>(), u.data_ptr<float>(),
+                         k.data_ptr<float>(), v.data_ptr<float>(), y.data_ptr<float>(),
+                         aa.data_ptr<float>(), bb.data_ptr<float>(), pp.data_ptr<float>());
+        break;
+    default:
+        assert(false && "Only FP16 and FP32 are currently supported");
+    }
 }
+
 void mm8_seq(int64_t B, int64_t N, int64_t M,
              torch::Tensor &x, torch::Tensor &w,
              torch::Tensor &mx, torch::Tensor &rx,
@@ -34,13 +58,28 @@ void mm8_seq(int64_t B, int64_t N, int64_t M,
     assert(my.stride(0) == 1 && ry.stride(0) == 1);
     assert(y.stride(1) == 1);
     const at::cuda::OptionalCUDAGuard device_guard(device_of(w));
-    cuda_mm8_seq(
-        B, N, M,
-        x.data_ptr<fp16>(), x.stride(0),
-        w.data_ptr<uint8_t>(), w.stride(0),
-        mx.data_ptr<fp16>(), rx.data_ptr<fp16>(),
-        my.data_ptr<fp16>(), ry.data_ptr<fp16>(),
-        y.data_ptr<fp16>(), y.stride(0));
+    switch (x.scalar_type()) {
+    case c10::ScalarType::Half:
+        cuda_mm8_seq(
+            B, N, M,
+            x.data_ptr<fp16>(), x.stride(0),
+            w.data_ptr<uint8_t>(), w.stride(0),
+            mx.data_ptr<fp16>(), rx.data_ptr<fp16>(),
+            my.data_ptr<fp16>(), ry.data_ptr<fp16>(),
+            y.data_ptr<fp16>(), y.stride(0));
+        break;
+    case c10::ScalarType::Float:
+        cuda_mm8_seq(
+            B, N, M,
+            x.data_ptr<float>(), x.stride(0),
+            w.data_ptr<uint8_t>(), w.stride(0),
+            mx.data_ptr<float>(), rx.data_ptr<float>(),
+            my.data_ptr<float>(), ry.data_ptr<float>(),
+            y.data_ptr<float>(), y.stride(0));
+        break;
+    default:
+        assert(false && "Only FP16 and FP32 are currently supported");
+    }
 }
 void mm8_one(int64_t N, int64_t M,
              torch::Tensor &x, torch::Tensor &w,
@@ -53,13 +92,28 @@ void mm8_one(int64_t N, int64_t M,
     assert(my.stride(0) == 1 && ry.stride(0) == 1);
     assert(y.stride(0) == 1);
     const at::cuda::OptionalCUDAGuard device_guard(device_of(w));
-    cuda_mm8_one(
-        N, M,
-        x.data_ptr<fp16>(),
-        w.data_ptr<uint8_t>(), w.stride(0),
-        mx.data_ptr<fp16>(), rx.data_ptr<fp16>(),
-        my.data_ptr<fp16>(), ry.data_ptr<fp16>(),
-        y.data_ptr<float>());
+    switch (x.scalar_type()) {
+    case c10::ScalarType::Half:
+        cuda_mm8_one(
+            N, M,
+            x.data_ptr<fp16>(),
+            w.data_ptr<uint8_t>(), w.stride(0),
+            mx.data_ptr<fp16>(), rx.data_ptr<fp16>(),
+            my.data_ptr<fp16>(), ry.data_ptr<fp16>(),
+            y.data_ptr<float>());
+        break;
+    case c10::ScalarType::Float:
+        cuda_mm8_one(
+            N, M,
+            x.data_ptr<float>(),
+            w.data_ptr<uint8_t>(), w.stride(0),
+            mx.data_ptr<float>(), rx.data_ptr<float>(),
+            my.data_ptr<float>(), ry.data_ptr<float>(),
+            y.data_ptr<float>());
+        break;
+    default:
+        assert(false && "Only FP16 and FP32 are currently supported");
+    }
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {


### PR DESCRIPTION
The problem is that we use CUDA op despite whether the weight is on GPU. Now both cuda fp32i8 and cpu fp32i8 works correctly together. WKV and MM8 ops in fp32 added to fix this.