### PR TITLE
Implement parallel Inference and Generation

### DIFF
--- a/rwkv_pip_package/src/rwkv/utils.py
+++ b/rwkv_pip_package/src/rwkv/utils.py
@@ -2,6 +2,8 @@
 # The RWKV Language Model - https://github.com/BlinkDL/RWKV-LM
 ########################################################################################################
 
+from functools import partial
+from itertools import chain
 import json, time, random, os
 import numpy as np
 import torch
@@ -101,6 +103,68 @@ class PIPELINE():
             out = torch.multinomial(probs, num_samples=1)[0]
             return int(out)
         
+    def infer(self, ctxs, *args, return_logits=False, **kwargs):
+        if isinstance(ctxs, str):
+            ctxs = [ctxs]
+        i, state, out = zip(*self.batch_infer(ctxs, *args, return_logits=True, **kwargs))
+
+        _, order = torch.tensor(i).sort()
+        state = [torch.stack(s)[order] for s in state]
+
+        out = torch.stack(out)
+
+        if return_logits:
+            return state, out
+        return state
+
+    def batch_infer(self, ctxs, args=PIPELINE_ARGS(), state=None, return_logits=False):
+        """
+        An iterator that yield the tuple (index, state, logits (optional)) of the ctx provided.
+        ctx can either be a string or list of strings
+        """
+        # forward & adjust prob.
+
+        if is_string:=isinstance(ctxs, str):
+            ctxs = [ctxs]
+
+        batch_tokens = [self.encode(ctx) for ctx in ctxs]
+        idxs = [[(i, j, token) for j, token in enumerate(tokens)] for i, tokens in enumerate(batch_tokens)]
+        idxs = list(chain(*idxs))
+        x, y, data = zip(*idxs)
+
+
+        batch_tensor = torch.zeros(max(x)+1, max(y)+1, dtype=torch.int64)
+        batch_tensor[x, y] = torch.tensor(data)
+
+        lens = [len(x) for x in batch_tokens]
+        out_state = None
+        complete = set()
+
+        
+        # 1/0
+        while batch_tensor.shape[-1] > 0:
+            
+            chunk_len = min(min([l for l in lens if l > 0]), args.chunk_len)
+            
+            out, state = self.model.forward(batch_tensor[:, :chunk_len], state)
+
+            # out, state = self.model.forward(batch_tensor[:, :args.chunk_len], state)
+            batch_tensor = batch_tensor[:, chunk_len:]
+
+            lens = [l-chunk_len for l in lens]
+            
+            for i in [i for i, l in enumerate(lens) if l<=0 and i not in complete]:
+                
+                complete = complete.union({i})
+
+                b_i_state = [s[i] for j, s in enumerate(state)]
+                
+                return_state = b_i_state if is_string else (i, b_i_state)
+                if return_logits:
+                    yield *return_state, out[i]
+                    continue
+                yield return_state
+                    
     def generate(self, *args, callback=None, **kwargs):
         outstr = []
         for delta in self.igenerate(*args, **kwargs):
@@ -110,28 +174,63 @@ class PIPELINE():
         return ''.join(outstr)
 
     def igenerate(self, ctx, token_count=100, args=PIPELINE_ARGS(), state=None):
+        if is_string := isinstance(ctx, str):
+            ctx = [ctx]
+        
+
+        batch_size = len(ctx)
+        
+        i, state, out = zip(*self.batch_infer(ctx, args, state=state, return_logits=True))
+        _, sorted_idxs = torch.tensor(i).sort()
+        
+        
+        out = torch.stack(out, axis=0)[sorted_idxs]
+        
+        state = [torch.stack(s, axis=0)[sorted_idxs] for s in zip(*state)]
+
+        samplers = [self.sampler_state_machine(logits, args, token_count) for logits in out]
+        [next(s) for s in samplers]
+        PAD = -1 ##??? is there a pad token? should be EOS? 
+        def ignore_stop_iter(sampler, logits):
+            try:
+                return sampler.send(logits)
+            except StopIteration as e:
+                return (PAD, None)
+        tokens = torch.zeros(batch_size, device=out.device).int()
+        while not (tokens==PAD).all():
+            tokens_tuple, samples = zip(*[ignore_stop_iter(s, logits) for s, logits in zip(samplers, out)])
+            tokens = tokens.new(tokens_tuple)
+            out, state = self.model.forward(tokens, state)
+            # out = out.squeeze(0)
+            if is_string:
+                
+                if samples[0] is not None:
+                    yield samples[0]
+                continue
+            yield samples 
+        
+    def sampler_state_machine(self, logits, args, token_count):
+    
         all_tokens = []
         out_last = 0
-        out_str = ''
         occurrence = {}
-
         stopword_checker = self.check_stopwords(args.stop_words)
+        
         next(stopword_checker)
+        yield
+        
+        
+        tmp = None
         for i in range(token_count):
+            
 
-            # forward & adjust prob.
-            tokens = self.encode(ctx) if i == 0 else [token]
-            while len(tokens) > 0:
-                out, state = self.model.forward(tokens[:args.chunk_len], state)
-                tokens = tokens[args.chunk_len:]
-                
             for n in args.token_ban:
-                out[n] = -float('inf')
+                logits[n] = -float('inf')
             for n in occurrence:
-                out[n] -= (args.alpha_presence + occurrence[n] * args.alpha_frequency)
+                logits[n] -= (args.alpha_presence + occurrence[n] * args.alpha_frequency)
             
             # sampler
-            token = self.sample_logits(out, temperature=args.temperature, top_p=args.top_p, top_k=args.top_k)
+            token = self.sample_logits(logits, temperature=args.temperature, top_p=args.top_p, top_k=args.top_k)
             if token in args.token_stop:
                 break
             all_tokens += [token]
@@ -142,47 +241,56 @@ class PIPELINE():
             
             # output
             tmp = self.decode(all_tokens[out_last:])
+            
+            # if len(all_tokens)==1:
+            #     tmp = tmp[1:] # strip leading space
+            if tmp == '':
+                continue
             if '\ufffd' not in tmp: # is valid utf-8 string?
+
                 try:
                     tmp = stopword_checker.send(tmp)
                 except StopIteration:
                     break
+                out_last = i + 1
+            
+            
+            logits = yield token, tmp
 
-                if tmp is None:
-                    continue
-
-                yield tmp
-                out_str += tmp
-                out_last = i + 1                
-
-    def check_stopwords(self, stop_words):
+    @staticmethod
+    def check_stopwords(stop_words):
         
         longest_stopword = 0 if len(stop_words)==0 else max(map(len, stop_words))
         chunk = ""
         delta = True
-        yield
+        # yield
+        to_yield = None
         while delta:
-            delta = yield
+            delta = yield to_yield
             chunk = chunk + delta
 
             if longest_stopword == 0:
                 # nothing to check just passthrough
-                yield delta
+                to_yield = delta
                 continue
+            if chunk == '':
+                to_yield = None
+                continue
+            if any(map(lambda stop_word: chunk.startswith(stop_word), stop_words)):
+                
+                return
 
             if start_idx := max(map(lambda stop_word: end_overlap(chunk, stop_word), stop_words)):
                 if start_idx > longest_stopword:
                     start_idx = longest_stopword  # can no longer be a stopword so cut it down
                 good, chunk = chunk[:-start_idx], chunk[-start_idx:]
-
                 if good:
-                    yield good
-
-                if any(map(lambda stop_word: chunk.startswith(stop_word), stop_words)):
-                    return
+                    to_yield = good
+                    continue
                 
-                yield None
+                to_yield = None
                 continue
-
-            yield chunk
+            
+            out = chunk
             chunk = ""
+            to_yield = out

--- a/rwkv_pip_package/src/rwkv/utils.py
+++ b/rwkv_pip_package/src/rwkv/utils.py
@@ -7,8 +7,30 @@ import numpy as np
 import torch
 from torch.nn import functional as F
 
+
+def end_overlap(a, b):
+    for i in range(1, len(a) + 1):
+        if b.startswith(a[-i:]):
+            return i
+    return 0
+
 class PIPELINE_ARGS():
-    def __init__(self, temperature=1.0, top_p=0.85, top_k=0, alpha_frequency=0.2, alpha_presence=0.2, token_ban=[], token_stop=[], chunk_len=256):
+    def __init__(self, 
+                 temperature=1.0, 
+                 top_p=0.85, 
+                 top_k=0, 
+                 alpha_frequency=0.2, 
+                 alpha_presence=0.2, 
+                 token_ban=None,
+                 token_stop=None,
+                 stop_words=None,
+                 chunk_len=256
+                ):
+        
+        token_ban = token_ban or []
+        token_stop = token_stop or []
+        stop_words = stop_words or []
+        
         self.temperature = temperature
         self.top_p = top_p
         self.top_k = top_k
@@ -16,6 +38,7 @@ class PIPELINE_ARGS():
         self.alpha_presence = alpha_presence # Presence Penalty (as in GPT-3)
         self.token_ban = token_ban # ban the generation of some tokens
         self.token_stop = token_stop # stop generation whenever you see any token here
+        self.stop_words = stop_words # stop generation whenever you see any token here
         self.chunk_len = chunk_len # split input into chunks to save VRAM (shorter -> slower)
 
 class PIPELINE():
@@ -77,12 +100,23 @@ class PIPELINE():
                 probs = probs ** (1.0 / temperature)
             out = torch.multinomial(probs, num_samples=1)[0]
             return int(out)
-    
-    def generate(self, ctx, token_count=100, args=PIPELINE_ARGS(), callback=None, state=None):
+        
+    def generate(self, *args, callback=None, **kwargs):
+        outstr = []
+        for delta in self.igenerate(*args, **kwargs):
+            outstr += [delta]
+            if callback:
+                callback(delta)
+        return ''.join(outstr)
+
+    def igenerate(self, ctx, token_count=100, args=PIPELINE_ARGS(), state=None):
         all_tokens = []
         out_last = 0
         out_str = ''
         occurrence = {}
+
+        stopword_checker = self.check_stopwords(args.stop_words)
+        next(stopword_checker)
         for i in range(token_count):
 
             # forward & adjust prob.
@@ -109,8 +143,46 @@ class PIPELINE():
             # output
             tmp = self.decode(all_tokens[out_last:])
             if '\ufffd' not in tmp: # is valid utf-8 string?
-                if callback:
-                    callback(tmp)
+                try:
+                    tmp = stopword_checker.send(tmp)
+                except StopIteration:
+                    break
+
+                if tmp is None:
+                    continue
+
+                yield tmp
                 out_str += tmp
-                out_last = i + 1
-        return out_str
+                out_last = i + 1                
+
+    def check_stopwords(self, stop_words):
+        
+        longest_stopword = 0 if len(stop_words)==0 else max(map(len, stop_words))
+        chunk = ""
+        delta = True
+        yield
+        while delta:
+            delta = yield
+            chunk = chunk + delta
+
+            if longest_stopword == 0:
+                # nothing to check just passthrough
+                yield delta
+                continue
+
+            if start_idx := max(map(lambda stop_word: end_overlap(chunk, stop_word), stop_words)):
+                if start_idx > longest_stopword:
+                    start_idx = longest_stopword  # can no longer be a stopword so cut it down
+                good, chunk = chunk[:-start_idx], chunk[-start_idx:]
+
+                if good:
+                    yield good
+
+                if any(map(lambda stop_word: chunk.startswith(stop_word), stop_words)):
+                    return
+                
+                yield None
+                continue
+
+            yield chunk
+            chunk = ""

--- a/rwkv_pip_package/src/rwkv/utils.py
+++ b/rwkv_pip_package/src/rwkv/utils.py
@@ -9,7 +9,7 @@ from torch.nn import functional as F
 
 
 def end_overlap(a, b):
-    for i in range(1, len(a) + 1):
+    for i in reversed(range(1, len(a) + 1)):
         if b.startswith(a[-i:]):
             return i
     return 0


### PR DESCRIPTION
note: commits [fix overlap should be checked in reverse](https://github.com/BlinkDL/ChatRWKV/commit/cd999efb1e4059178e04b4ecf0b051a70be20ef5) and [feat: add stopword checker + iterable generate function](https://github.com/BlinkDL/ChatRWKV/commit/45ea8563cc592baf00b5d1475726251af6c70172) are from the implement stopwords PR.

I've only tested with the strategy `cpu fp32 *1` but I think it should work for all strategies.

The parallel sampling method builds heavily on logic implemented in the stopword PR and the commits don't really define good boundaries. Let me know if you want me to fix that. If you merge this then the other can deleted

Otherwise seems to be running quite smoothly with what I've tried. Let me know what you think about it all and if there is any obvious math issues I've introduced!

----

some examples that I should document

initialise
```python
import gc
import logging
import os
from pathlib import Path

import requests
import torch
from huggingface_hub import hf_hub_download
os.environ["RWKV_JIT_ON"] = "0"
os.environ["RWKV_CUDA_ON"] = "0"
from rwkv.model import RWKV  # noqa: E402
from rwkv.utils import PIPELINE, PIPELINE_ARGS  # noqa: E402

ctx_limit = 4096

models = {
    "raven-14b-ctx4096": {
        "repo_id": "BlinkDL/rwkv-4-raven",
        "title": "RWKV-4-Raven-14B-v8-Eng-20230408-ctx4096",
    },
    "raven-7b-ctx4096": {
        "repo_id": "BlinkDL/rwkv-4-raven",
        "title": "RWKV-4-Raven-7B-v7-Eng-20230404-ctx4096",
    },
    "raven-7b-ctx1024": {
        "repo_id": "BlinkDL/rwkv-4-pile-7b",
        "title": "RWKV-4-Pile-7B-Instruct-test4-20230326",
    },
    "rwkv-4-pile-169m": {
        "repo_id": "BlinkDL/rwkv-4-pile-169m",
        "title": "RWKV-4-Pile-169M-20220807-8023",
    },
        "raven-1b-ctx4096": {
        "repo_id": "BlinkDL/rwkv-4-raven",
        "title": "RWKV-4-Raven-1B5-v11-Eng99%-Other1%-20230425-ctx4096",
    },
}

model = "raven-1b-ctx4096"
model_params = models[model]


def fetch_tokenizer(tokenizer_path: Path):
    url = "https://huggingface.co/spaces/BlinkDL/Raven-RWKV-7B/raw/main/20B_tokenizer.json"
    tokenizer_path.parent.mkdir(exist_ok=True)

    response = requests.get(url)
    tokenizer_path.write_bytes(response.content)


def get_model():
    tokenizer_path = Path(__file__).parent / "20B_tokenizer.json"
    if not tokenizer_path.exists():
        fetch_tokenizer(tokenizer_path)

    model_path = hf_hub_download(
        repo_id=model_params["repo_id"], filename=f"{model_params['title']}.pth"
    )

    model = RWKV(
        model=model_path, strategy="cpu fp32 *0"
    )  # stream mode w/some static

    pipeline = PIPELINE(model, str(tokenizer_path))

    return model, pipeline

model, pipeline = get_model()
```

Generate parallel
```python
>>> questions = [
    'Bob: whats the day?\n\nAlice:',
    'Bob: whats the time?\n\nAlice:',
    'Bob: this is an obnoxiosuly long question, so much longer than the rest?\n\nAlice:',
    'Bob: whats the sound?\n\nAlice:',
    'Bob: whats the delay?\n\nAlice:',
]
>>> for i in pipeline.igenerate(questions, token_count=250, args=PIPELINE_ARGS(chunk_len=256, stop_words='Bob:')):
>>>     print(i)
```
Generate single
```python
>>> for i in pipeline.igenerate('Bob: whats the day?\n\nAlice:', args=PIPELINE_ARGS(stop_words='Bob:')):
>>>     print(i, sep='', end='', flush=True)
 It is Saturday, April 28th.
```

Infer single
```python 
>>> state = pipeline.infer('Bob: whats the day?\n\nalice:')
[tensor([[ 0.0067, -0.0483, -0.1088,  ..., -0.0043,  0.0065,  0.0251]])]
```

Infer parallel
```python
>>> pipeline.infer(questions)
[tensor([[ 0.0067, -0.0483, -0.1088,  ..., -0.0043,  0.0065,  0.0251],
         [-0.8015, -0.3936,  2.3798,  ...,  0.3735, -0.0855, -0.8532],
         [ 0.0090,  0.0298, -0.0651,  ...,  0.0129, -0.0053,  0.0163],
         [ 1.6057,  2.8717,  3.0602,  ...,  1.0000,  1.0000,  1.0000],
         [ 2.6282,  2.8281,  1.6604,  ..., -2.7151,  2.5806,  1.6659]]),
 tensor([[ 0.0067, -0.0483, -0.1088,  ..., -0.0043,  0.0065,  0.0251],
         [-0.7918, -0.8789,  1.8799,  ...,  0.3735, -0.0855, -0.8532],
         [ 0.0082,  0.0315, -0.0668,  ...,  0.0112, -0.0041,  0.0179],
         [ 1.5889,  2.3284,  2.8709,  ...,  1.0000,  1.0000,  1.0000],
         [ 2.6282,  2.8281,  1.6604,  ..., -2.7151,  2.5806,  1.6659]]),
 tensor([[ 6.6986e-03, -4.8346e-02, -1.0882e-01,  ..., -4.3214e-03,
           6.4733e-03,  2.5146e-02],
         [-7.9228e-01,  1.3874e+00,  2.3622e+00,  ...,  3.7351e-01,
          -8.5515e-02, -8.5321e-01],
         [ 8.2001e-03,  3.2023e-02, -6.6461e-02,  ...,  1.0814e-02,
          -2.8179e-03,  1.6461e-02],
         [ 1.5827e+00,  2.4019e+00,  2.9919e+00,  ...,  1.0000e+00,
           1.0000e+00,  1.0000e+00],
         [ 2.6282e+00,  3.2905e+00,  1.6604e+00,  ..., -2.7151e+00,
           2.5806e+00,  1.6659e+00]]),
 tensor([[ 6.6986e-03, -4.8346e-02, -1.0882e-01,  ..., -4.3214e-03,
           6.4733e-03,  2.5146e-02],
         [-7.8120e-01, -1.3236e+00,  1.9415e+00,  ...,  3.7351e-01,
          -8.5515e-02, -8.5321e-01],
         [ 1.1746e-02,  3.3171e-02, -6.4305e-02,  ...,  1.0538e-02,
          -5.1670e-04,  1.7817e-02],
         [ 1.5925e+00,  2.5117e+00,  3.0401e+00,  ...,  1.0000e+00,
           1.0000e+00,  1.0000e+00],
         [ 2.6282e+00,  2.8281e+00,  1.6604e+00,  ..., -2.7151e+00,
           2.5806e+00,  1.6659e+00]]),
 tensor([[ 6.6986e-03, -4.8346e-02, -1.0882e-01,  ..., -4.3214e-03,
           6.4733e-03,  2.5146e-02],
         [-1.1770e-02, -4.1843e-01,  2.1849e+00,  ...,  3.7351e-01,
          -8.5515e-02, -8.5321e-01],
         [ 1.4248e-02,  4.4202e-02, -7.8099e-02,  ...,  1.5142e-02,
          -5.2775e-04,  2.7968e-02],
         [ 3.9415e+00,  2.2419e+00,  7.9089e+00,  ...,  1.0000e+00,
           1.0000e+00,  1.0000e+00],
         [ 2.3895e+00,  3.5548e+00,  1.8283e+00,  ..., -2.7151e+00,
           2.5806e+00,  1.6659e+00]])]
```


