### PR TITLE
fix top_p sampling when cumsum exactly equals to top_p

### DIFF
--- a/rwkv_pip_package/src/rwkv/utils.py
+++ b/rwkv_pip_package/src/rwkv/utils.py
@@ -60,7 +60,7 @@ class PIPELINE():
             sorted_ids = np.argsort(probs)
             sorted_probs = probs[sorted_ids][::-1]
             cumulative_probs = np.cumsum(sorted_probs)
-            cutoff = float(sorted_probs[np.argmax(cumulative_probs > top_p)])
+            cutoff = float(sorted_probs[np.argmax(cumulative_probs >= top_p)])
             probs[probs < cutoff] = 0
             if top_k < len(probs) and top_k > 0:
                 probs[sorted_ids[:-top_k]] = 0
@@ -74,7 +74,7 @@ class PIPELINE():
             sorted_probs = probs[sorted_ids]
             sorted_probs = torch.flip(sorted_probs, dims=(0,))
             cumulative_probs = torch.cumsum(sorted_probs, dim=-1).cpu().numpy()
-            cutoff = float(sorted_probs[np.argmax(cumulative_probs > top_p)])
+            cutoff = float(sorted_probs[np.argmax(cumulative_probs >= top_p)])
             probs[probs < cutoff] = 0
             if top_k < len(probs) and top_k > 0:
                 probs[sorted_ids[:-top_k]] = 0

--- a/src/utils.py
+++ b/src/utils.py
@@ -45,7 +45,7 @@ class TOKENIZER():
             probs = probs.numpy()
             sorted_probs = np.sort(probs)[::-1]
             cumulative_probs = np.cumsum(sorted_probs)
-            cutoff = float(sorted_probs[np.argmax(cumulative_probs > top_p)])
+            cutoff = float(sorted_probs[np.argmax(cumulative_probs >= top_p)])
             probs[probs < cutoff] = 0
             if temperature != 1.0:
                 probs = probs ** (1.0 / temperature)
@@ -55,7 +55,7 @@ class TOKENIZER():
         else:
             sorted_probs = torch.sort(probs, descending=True)[0]
             cumulative_probs = torch.cumsum(sorted_probs, dim=-1).cpu().numpy()
-            cutoff = float(sorted_probs[np.argmax(cumulative_probs > top_p)])
+            cutoff = float(sorted_probs[np.argmax(cumulative_probs >= top_p)])
             probs[probs < cutoff] = 0
             if temperature != 1.0:
                 probs = probs ** (1.0 / temperature)


### PR DESCRIPTION
Fix the following bugs:

1. When top_p = 1, `np.argmax(cumulative_probs > top_p)` will unexpectly be 0 (so the token with the largest logit will always be selected) because `cumulative_probs > top_p` is all False
2. When top_p exactly equals to another cumsum, it will samples an extra token. Similar issue: https://github.com/huggingface/transformers/issues/18976