### PR TITLE
fix jit

### DIFF
--- a/rwkv_pip_package/src/rwkv/model.py
+++ b/rwkv_pip_package/src/rwkv/model.py
@@ -86,9 +86,61 @@ if os.environ.get('RWKV_CUDA_ON') == '1':
 else:
     os.environ["RWKV_CUDA_ON"] = '0'
 
-if os.environ.get('RWKV_CUDA_ON') == '1' and not DISABLE_CUBLAS_GEMM:
+
+@MyStatic
+def torch_mm8_seq(x, w, mx, rx, my, ry):
+    return x @ ((w.to(dtype=x.dtype) + 0.5) * ry * rx + my + mx)
+
+@MyStatic
+def torch_mm8_one(x, w, mx, rx, my, ry):
+    return x @ ((w.to(dtype=x.dtype) + 0.5) * ry * rx + my + mx)
+
+if os.environ.get('RWKV_CUDA_ON') == '1':
     @MyStatic
-    def matmul_float(a, b, *, output_dtype: Optional[torch.dtype]=None):
+    def mm8_seq(x, w, mx, rx, my, ry):
+        if w.device.type == 'cuda' and x.dtype == torch.float16:
+            B, N, M = x.shape[0], w.shape[0], w.shape[1]
+            return cuda_mm8_seq(B, N, M, x, w, mx, rx, my, ry)
+        else:
+            return torch_mm8_seq(x, w, mx, rx, my, ry)
+    @MyStatic
+    def mm8_one(x, w, mx, rx, my, ry):
+        if w.device.type == 'cuda':
+            N, M = w.shape[0], w.shape[1]
+            return cuda_mm8_one(N, M, x, w, mx, rx, my, ry)
+        else:
+            return torch_mm8_one(x, w, mx, rx, my, ry)
+else:
+    @MyStatic
+    def mm8_seq(x, w, mx, rx, my, ry):
+        return torch_mm8_seq(x, w, mx, rx, my, ry)
+    @MyStatic
+    def mm8_one(x, w, mx, rx, my, ry):
+        return torch_mm8_one(x, w, mx, rx, my, ry)
+
+def mm8(x: torch.Tensor, w: torch.Tensor, mx: torch.Tensor, rx: torch.Tensor, my: torch.Tensor, ry: torch.Tensor):
+    if len(x.shape) == 1:
+        return mm8_one(x, w, mx, rx, my, ry)
+    return mm8_seq(x, w, mx, rx, my, ry)
+
+def matmul(a, b, mx: Optional[torch.Tensor]=None, rx: Optional[torch.Tensor]=None, my: Optional[torch.Tensor]=None, ry: Optional[torch.Tensor]=None, output_dtype: Optional[torch.dtype]=None) -> torch.Tensor:
+    if output_dtype is None:
+        output_dtype = a.dtype
+    if b.dtype == torch.float16 or b.dtype == torch.float32:
+        assert a.dtype == b.dtype
+        return matmul_float(a, b, output_dtype=output_dtype)
+    elif b.dtype == torch.uint8:
+        assert mx is not None
+        assert rx is not None
+        assert my is not None
+        assert ry is not None
+        return mm8(a, b, mx, rx, my, ry).to(output_dtype)
+    else:
+        raise ValueError("Unsupported dtype")
+
+
+if os.environ.get('RWKV_CUDA_ON') == '1' and not DISABLE_CUBLAS_GEMM:
+    def matmul_float(a, b, output_dtype: Optional[torch.dtype]=None):
         if output_dtype is None:
             output_dtype = a.dtype
         if a.dtype == b.dtype == torch.float16 and a.device.type == 'cuda':
@@ -110,9 +162,9 @@ if os.environ.get('RWKV_CUDA_ON') == '1' and not DISABLE_CUBLAS_GEMM:
             return (a @ b).to(output_dtype)
 
 else:
-    @MyStatic
-    def matmul_float(a, b, *, output_dtype: Optional[torch.dtype]=None):
+    def matmul_float(a, b, output_dtype: Optional[torch.dtype]=None):
         return (a @ b).to(output_dtype)
+
 
 if os.environ.get('RWKV_DML_ON') == '1':
     import torch_directml
@@ -443,54 +495,6 @@ class RWKV(MyModule):
     def RUN_RWKV_5(self, B, T, C, H, state, r, k, v, w, u):
         return self.RWKV_5.apply(B, T, C, H, state, r, k, v, w, u)            
 
-    @MyFunction
-    def torch_mm8_seq(self, x, w, mx, rx, my, ry):
-        return x @ ((w.to(dtype=x.dtype) + 0.5) * ry * rx + my + mx)
-
-    @MyFunction
-    def torch_mm8_one(self, x, w, mx, rx, my, ry):
-        return x @ ((w.to(dtype=x.dtype) + 0.5) * ry * rx + my + mx)
-
-    if os.environ.get('RWKV_CUDA_ON') == '1':
-        @MyFunction
-        def mm8_seq(self, x, w, mx, rx, my, ry):
-            if w.device.type == 'cuda' and x.dtype == torch.float16:
-                B, N, M = x.shape[0], w.shape[0], w.shape[1]
-                return cuda_mm8_seq(B, N, M, x, w, mx, rx, my, ry)
-            else:
-                return self.torch_mm8_seq(x, w, mx, rx, my, ry)
-        @MyFunction
-        def mm8_one(self, x, w, mx, rx, my, ry):
-            if w.device.type == 'cuda':
-                N, M = w.shape[0], w.shape[1]
-                return cuda_mm8_one(N, M, x, w, mx, rx, my, ry)
-            else:
-                return self.torch_mm8_one(x, w, mx, rx, my, ry)
-    else:
-        @MyFunction
-        def mm8_seq(self, x, w, mx, rx, my, ry):
-            return self.torch_mm8_seq(x, w, mx, rx, my, ry)
-        @MyFunction
-        def mm8_one(self, x, w, mx, rx, my, ry):
-            return self.torch_mm8_one(x, w, mx, rx, my, ry)
-
-    @MyFunction
-    def mm8(self, x, w, mx, rx, my, ry):
-        if len(x.shape) == 1:
-            return self.mm8_one(x, w, mx, rx, my, ry)
-        return self.mm8_seq(x, w, mx, rx, my, ry)
-
-    @MyStatic
-    def matmul(self, a, b, mx=None, rx=None, my=None, ry=None, *, output_dtype: Optional[torch.dtype]=None) -> torch.Tensor:
-        if output_dtype is None:
-            output_dtype = a.dtype
-        if b.dtype == torch.float16 or b.dtype == torch.float32:
-            assert a.dtype == b.dtype
-            return matmul_float(a, b, output_dtype=output_dtype)
-        if b.dtype == torch.uint8:
-            return self.mm8(a, b, mx, rx, my, ry).to(output_dtype)
-
-
     ########################################################################################################
 
     @MyFunction
@@ -499,9 +503,9 @@ class RWKV(MyModule):
         kx = xx * k_mix + sx * (1 - k_mix)
         rx = xx * r_mix + sx * (1 - r_mix)
 
-        r = torch.sigmoid(self.matmul(rx, rw, rmx, rrx, rmy, rry))
-        vx = torch.square(torch.relu(self.matmul(kx, kw, kmx, krx, kmy, kry)))
-        out = r * self.matmul(vx, vw, vmx, vrx, vmy, vry)
+        r = torch.sigmoid(matmul(rx, rw, rmx, rrx, rmy, rry))
+        vx = torch.square(torch.relu(matmul(kx, kw, kmx, krx, kmy, kry)))
+        out = r * matmul(vx, vw, vmx, vrx, vmy, vry)
         return x + out, xx
 
     ########################################################################################################
@@ -513,9 +517,9 @@ class RWKV(MyModule):
         kx = xx * k_mix + sx * (1 - k_mix)
         rx = xx * r_mix + sx * (1 - r_mix)
 
-        r = torch.sigmoid(self.matmul(rx, rw, rmx, rrx, rmy, rry))
-        vx = torch.square(torch.relu(self.matmul(kx, kw, kmx, krx, kmy, kry)))
-        out = r * self.matmul(vx, vw, vmx, vrx, vmy, vry)
+        r = torch.sigmoid(matmul(rx, rw, rmx, rrx, rmy, rry))
+        vx = torch.square(torch.relu(matmul(kx, kw, kmx, krx, kmy, kry)))
+        out = r * matmul(vx, vw, vmx, vrx, vmy, vry)
         return x + out, xx[-1,:]
 
     ########################################################################################################
@@ -527,9 +531,9 @@ class RWKV(MyModule):
         vx = xx * v_mix + sx * (1 - v_mix)
         rx = xx * r_mix + sx * (1 - r_mix)
 
-        r = torch.sigmoid(self.matmul(rx, rw, rmx, rrx, rmy, rry))
-        k = self.matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32)
-        v = self.matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32)
+        r = torch.sigmoid(matmul(rx, rw, rmx, rrx, rmy, rry))
+        k = matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32)
+        v = matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32)
 
         ww = t_first + k
         p = torch.maximum(pp, ww)
@@ -541,7 +545,7 @@ class RWKV(MyModule):
         e1 = torch.exp(ww - p)
         e2 = torch.exp(k - p)
 
-        out = self.matmul(r * wkv, ow, omx, orx, omy, ory)
+        out = matmul(r * wkv, ow, omx, orx, omy, ory)
         return x + out, xx, e1 * aa + e2 * v, e1 * bb + e2, p
 
     ########################################################################################################
@@ -554,9 +558,9 @@ class RWKV(MyModule):
         vx = xx * v_mix + sx * (1 - v_mix)
         rx = xx * r_mix + sx * (1 - r_mix)
 
-        r = torch.sigmoid(self.matmul(rx, rw, rmx, rrx, rmy, rry))
-        k = self.matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32)
-        v = self.matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32)
+        r = torch.sigmoid(matmul(rx, rw, rmx, rrx, rmy, rry))
+        k = matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32)
+        v = matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32)
 
         T = x.shape[0]
         for t in range(T):
@@ -574,7 +578,7 @@ class RWKV(MyModule):
             aa = e1 * aa + e2 * vv
             bb = e1 * bb + e2
             pp = p
-        out = self.matmul(r * sx, ow, omx, orx, omy, ory)
+        out = matmul(r * sx, ow, omx, orx, omy, ory)
         return x + out, xx[-1,:], aa, bb, pp
 
     ########################################################################################################
@@ -589,18 +593,18 @@ class RWKV(MyModule):
         H = t_decay.shape[0]
         S = x.shape[-1] // H
 
-        r = self.matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32).view(H, 1, S)
-        k = self.matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32).view(H, S, 1)
-        v = self.matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32).view(H, 1, S)
+        r = matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32).view(H, 1, S)
+        k = matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32).view(H, S, 1)
+        v = matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32).view(H, 1, S)
         
-        a = self.matmul(k, v)
+        a = matmul(k, v)
         out = r @ (t_first * a + s)
         s = a + t_decay * s
 
         out = out.flatten()
         out = F.group_norm(out.unsqueeze(0), num_groups=H, weight=lx_w, bias=lx_b).squeeze(0)
         out = out.to(dtype=x.dtype)
-        out = self.matmul(out, ow, omx, orx, omy, ory)
+        out = matmul(out, ow, omx, orx, omy, ory)
 
         return x + out, xx, s
 
@@ -629,9 +633,9 @@ class RWKV(MyModule):
         w = w[:, :-T].reshape(-1, T, 2 * T - 1)
         w = w[:, :, T-1:].reshape(H, T, T)
 
-        r = self.matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
-        k = self.matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1).transpose(-2, -1)
-        v = self.matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
+        r = matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
+        k = matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1).transpose(-2, -1)
+        v = matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
 
         out = ((r @ k) * w) @ v + (r @ s) * wb
         s = ws * s + (k * wk) @ v
@@ -639,7 +643,7 @@ class RWKV(MyModule):
         out = out.transpose(0, 1).contiguous().reshape(T, H*S)
         out = F.group_norm(out, num_groups=H, weight=lx_w, bias=lx_b)
         out = out.to(dtype=x.dtype)
-        out = self.matmul(out, ow, omx, orx, omy, ory)
+        out = matmul(out, ow, omx, orx, omy, ory)
 
         return x + out, xx[-1,:], s
 
@@ -656,24 +660,24 @@ class RWKV(MyModule):
         H = t_decay.shape[0]
         S = x.shape[-1] // H
 
-        r = self.matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32).view(H, 1, S)
-        k = self.matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32).view(H, S, 1)
-        v = self.matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32).view(H, 1, S)
-        g = F.silu(self.matmul(gx, gw, gmx, grx, gmy, gry))
+        r = matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32).view(H, 1, S)
+        k = matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32).view(H, S, 1)
+        v = matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32).view(H, 1, S)
+        g = F.silu(matmul(gx, gw, gmx, grx, gmy, gry))
         
-        a = self.matmul(k, v)
+        a = matmul(k, v)
         out = r @ (t_first * a + s)
         s = a + t_decay * s
 
         out = out.flatten()
         out = F.group_norm(out.unsqueeze(0), num_groups=H, weight=lx_w, bias=lx_b).squeeze(0)
         out = out.to(dtype=x.dtype) * g
-        out = self.matmul(out, ow, omx, orx, omy, ory)
+        out = matmul(out, ow, omx, orx, omy, ory)
 
         return x + out, xx, s
 
     @MyFunction
-    def att_seq_v5_1(self, x, sx, s, ln_w, ln_b, lx_w, lx_b, k_mix, v_mix, r_mix, g_mix, t_decay, t_first, kw, vw, rw, gw, ow, kmx, krx, kmy, kry, vmx, vrx, vmy, vry, rmx, rrx, rmy, rry, omx, orx, omy, ory):
+    def att_seq_v5_1(self, x, sx, s, ln_w, ln_b, lx_w, lx_b, k_mix, v_mix, r_mix, g_mix, t_decay, t_first, kw, vw, rw, gw, ow, kmx, krx, kmy, kry, vmx, vrx, vmy, vry, rmx, rrx, rmy, rry, gmx, grx, gmy, gry, omx, orx, omy, ory):
         xx = F.layer_norm(x, (x.shape[-1],), weight=ln_w, bias=ln_b)
         sx = torch.cat((sx.unsqueeze(0), xx[:-1,:]))
         kx = xx * k_mix + sx * (1 - k_mix)
@@ -698,10 +702,10 @@ class RWKV(MyModule):
         w = w[:, :-T].reshape(-1, T, 2 * T - 1)
         w = w[:, :, T-1:].reshape(H, T, T)
 
-        r = self.matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
-        k = self.matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1).transpose(-2, -1)
-        v = self.matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
-        g = F.silu(self.matmul(gx, gw, gmx, grx, gmy, gry))
+        r = matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
+        k = matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1).transpose(-2, -1)
+        v = matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
+        g = F.silu(matmul(gx, gw, gmx, grx, gmy, gry))
 
         out = ((r @ k) * w) @ v + (r @ s) * wb
         s = ws * s + (k * wk) @ v
@@ -709,7 +713,7 @@ class RWKV(MyModule):
         out = out.transpose(0, 1).contiguous().reshape(T, H*S)
         out = F.group_norm(out, num_groups=H, weight=lx_w, bias=lx_b)
         out = out.to(dtype=x.dtype) * g
-        out = self.matmul(out, ow, omx, orx, omy, ory)
+        out = matmul(out, ow, omx, orx, omy, ory)
 
         return x + out, xx[-1,:], s
 
@@ -728,24 +732,24 @@ class RWKV(MyModule):
         S = x.shape[-1] // H
         T = x.shape[0]
 
-        r = self.matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
-        k = self.matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1).transpose(-2, -1)
-        v = self.matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
-        g = F.silu(self.matmul(gx, gw, gmx, grx, gmy, gry))
+        r = matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
+        k = matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1).transpose(-2, -1)
+        v = matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32).view(T, H, S).transpose(0, 1)
+        g = F.silu(matmul(gx, gw, gmx, grx, gmy, gry))
 
         out = torch.empty((T, H, S), dtype=r.dtype, device=r.device)
         for t in range(T):
             rt = r[:,t:t+1,:]
             kt = k[:,:,t:t+1]
             vt = v[:,t:t+1,:]
-            at = self.matmul(kt, vt)
+            at = matmul(kt, vt)
             out[t] = (rt @ (t_first * at + s)).squeeze(1)
             s = at + t_decay * s
 
         out = out.reshape(T, H*S)
         out = F.group_norm(out, num_groups=H, weight=lx_w, bias=lx_b)
         out = out.to(dtype=x.dtype) * g
-        out = self.matmul(out, ow, omx, orx, omy, ory)
+        out = matmul(out, ow, omx, orx, omy, ory)
 
         return x + out, xx[-1,:], s
 
@@ -761,12 +765,12 @@ class RWKV(MyModule):
             vx = xx * v_mix + sx * (1 - v_mix)
             rx = xx * r_mix + sx * (1 - r_mix)
 
-            r = torch.sigmoid(self.matmul(rx, rw, rmx, rrx, rmy, rry))
-            k = self.matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32)
-            v = self.matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32)
+            r = torch.sigmoid(matmul(rx, rw, rmx, rrx, rmy, rry))
+            k = matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32)
+            v = matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32)
             y, aa, bb, pp = cuda_wkv(T, C, t_decay, t_first, k, v, aa, bb, pp)
 
-            out = self.matmul(r * y.to(x.dtype), ow, omx, orx, omy, ory)
+            out = matmul(r * y.to(x.dtype), ow, omx, orx, omy, ory)
             return x + out, xx[-1,:], aa, bb, pp
 
         # NOTE: decorate with @MyFunction causes JIT error
@@ -782,10 +786,10 @@ class RWKV(MyModule):
             N = x.shape[-1] // H
             T = x.shape[0]
 
-            r = self.matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32)
-            k = self.matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32)
-            v = self.matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32)
-            g = F.silu(self.matmul(gx, gw, gmx, grx, gmy, gry))
+            r = matmul(rx, rw, rmx, rrx, rmy, rry, output_dtype=torch.float32)
+            k = matmul(kx, kw, kmx, krx, kmy, kry, output_dtype=torch.float32)
+            v = matmul(vx, vw, vmx, vrx, vmy, vry, output_dtype=torch.float32)
+            g = F.silu(matmul(gx, gw, gmx, grx, gmy, gry))
 
             out, s = self.RUN_RWKV_5(1, T, self.args.n_att, H, s.transpose(-1,-2).contiguous(), r, k, v, w=t_decay, u=t_first)
             s = s.transpose(-1,-2)
@@ -793,7 +797,7 @@ class RWKV(MyModule):
             out = out.reshape(T, H*N)
             out = F.group_norm(out, num_groups=H, weight=lx_w, bias=lx_b)
             out = out.to(dtype=x.dtype) * g
-            out = self.matmul(out, ow, omx, orx, omy, ory)
+            out = matmul(out, ow, omx, orx, omy, ory)
 
             return x + out, xx[-1,:], s
 
@@ -989,8 +993,8 @@ class RWKV(MyModule):
                 x = x @ w['head.weight']
             else:
                 if seq_mode and full_output:
-                    x = self.mm8_seq(x, w['head.weight'], w['head.weight_mx'], w['head.weight_rx'], w['head.weight_my'], w['head.weight_ry'])
+                    x = mm8_seq(x, w['head.weight'], w['head.weight_mx'], w['head.weight_rx'], w['head.weight_my'], w['head.weight_ry'])
                 else:
-                    x = self.mm8_one(x, w['head.weight'], w['head.weight_mx'], w['head.weight_rx'], w['head.weight_my'], w['head.weight_ry'])
+                    x = mm8_one(x, w['head.weight'], w['head.weight_mx'], w['head.weight_rx'], w['head.weight_my'], w['head.weight_ry'])
 
             return x.float(), state


### PR DESCRIPTION
move some methods to the global scope to fix the error:

```
  File "/ChatRWKV/v2/../rwkv_pip_package/src/rwkv/model.py", line 484, in RWKV
    def matmul(self, a, b, mx=None, rx=None, my=None, ry=None, output_dtype: Optional[torch.dtype]=None) -> torch.Tensor:
  File "/usr/local/lib/python3.8/dist-packages/torch/jit/_script.py", line 1381, in script
    fn = torch._C._jit_script_compile(
RuntimeError:
'Tensor (inferred)' object has no attribute or method 'mm8'.:
  File "/ChatRWKV/v2/../rwkv_pip_package/src/rwkv/model.py", line 491
            return matmul_float(a, b, output_dtype=output_dtype)
        if b.dtype == torch.uint8:
            return self.mm8(a, b, mx, rx, my, ry).to(output_dtype)
                   ~~~~~~~~ <--- HERE
```

Add explicit type annotation to fix the error:

```
  File "/usr/local/lib/python3.8/dist-packages/torch/jit/_script.py", line 1381, in script
    fn = torch._C._jit_script_compile(
RuntimeError:

mm8(Tensor x, Tensor w, Tensor mx, Tensor rx, Tensor my, Tensor ry) -> Tensor:
Expected a value of type 'Tensor (inferred)' for argument 'mx' but instead found type 'Optional[Tensor]'.
Inferred 'mx' to be of type 'Tensor' because it was not annotated with an explicit type.
:
  File "/ChatRWKV/v2/../rwkv_pip_package/src/rwkv/model.py", line 137
        return matmul_float(a, b, output_dtype=output_dtype)
    elif b.dtype == torch.uint8:
        return mm8(a, b, mx, rx, my, ry).to(output_dtype)
               ~~~ <--- HERE
    else:
        raise ValueError("Unsupported dtype")
'matmul' is being compiled since it was called from 'RWKV.att_one'
```

Tested on v5/v4 models with jit on/off.